### PR TITLE
Add BlockWeights for types.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ const api = await ApiPromise.create({
     RefCount: 'u32',
     ChainId: 'u8',
     ResourceId: '[u8; 32]',
-    DepositNonce: 'u64'
+    DepositNonce: 'u64',
+    BlockWeights:'u32'
   }
 });
 ```


### PR DESCRIPTION
We are developing a dApp for token batch-sending on  Stafi blockchain https://stafi.bulksender.app, its worked without BlockWeights 2 weeks ago, but today when we tested again, its failed with the error message '2021-01-16 14:39:17        REGISTRY: Error: Cannot construct unknown type BlockWeights', after changed it, all things are good